### PR TITLE
Feature/use existing roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,9 @@ The identity pool id is returned in the cloud formation output when this project
     ]
 }
 ```
+
+## Obtaining AWS credentials
+This project supplies a sample python [cognito-client](scripts/cognito_client.py) for using the veda-auth stack. The [temporary credentials notebook](scripts/temporary-credentials-example.ipynb) demonstrates how to use the deployed veda-auth stack to obtain AWS credentials via a password authentication flow.
+
+### [PyPI cognito_client](https://pypi.org/project/cognito-client/)
+A streamlined version of the client can be installed with `pip install cognito_client`, see usage instructions [here](https://github.com/developmentseed/cognito_client#use).

--- a/app.py
+++ b/app.py
@@ -57,6 +57,14 @@ stack.add_cognito_group(
     },
 )
 
+# Create a data managers group in user pool if data managers role is provided
+if data_managers_role_arn := config.data_managers_role_arn:
+    stack.add_cognito_group_with_existing_role(
+        "veda-data-store-managers",
+        "Authenticated users assume read write veda data access role",
+        role_arn=data_managers_role_arn
+    )
+
 
 # Generate a resource server (ie something to protect behind auth) with scopes
 # (permissions that we can grant to users/services).

--- a/app.py
+++ b/app.py
@@ -20,6 +20,14 @@ stack = AuthStack(
     },
 )
 
+# Create a data managers group in user pool if data managers role is provided
+if data_managers_role_arn := config.data_managers_role_arn:
+    stack.add_cognito_group_with_existing_role(
+        "veda-data-store-managers",
+        "Authenticated users assume read write veda data access role",
+        role_arn=data_managers_role_arn
+    )
+
 # Create Groups
 stack.add_cognito_group(
     "veda-staging-writers",
@@ -56,15 +64,6 @@ stack.add_cognito_group(
         "veda-data-store": BucketPermissions.read_only,
     },
 )
-
-# Create a data managers group in user pool if data managers role is provided
-if data_managers_role_arn := config.data_managers_role_arn:
-    stack.add_cognito_group_with_existing_role(
-        "veda-data-store-managers",
-        "Authenticated users assume read write veda data access role",
-        role_arn=data_managers_role_arn
-    )
-
 
 # Generate a resource server (ie something to protect behind auth) with scopes
 # (permissions that we can grant to users/services).

--- a/config.py
+++ b/config.py
@@ -24,3 +24,7 @@ class Config(pydantic.BaseSettings):
         ),
         default_factory=getuser,
     )
+    data_managers_role_arn: str = pydantic.Field(
+        None,
+        description="ARN of role to be assumed by authenticated users in data managers group.",
+    )

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -372,7 +372,7 @@ class AuthStack(Stack):
         role_arn: str,
     ) -> cognito.CfnUserPoolGroup:
 
-        # Add identity pool to trust policy of role to be assumed by authenticated users in this group
+        # Add identity pool to trust policy of authenticated users role
         self._grant_authenticated_role_principal(role_arn=role_arn)
 
         return cognito.CfnUserPoolGroup(

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -60,9 +60,15 @@ class AuthStack(Stack):
         )
         CfnOutput(
             self,
-            f"identitypool_client_id",
+            "identitypool_client_id",
             export_name=f"{stack_name}-client-id",
             value=auth_provider_client.user_pool_client_id,
+        )
+        CfnOutput(
+            self,
+            "identitypool_data_managers_role_arn",
+            export_name=f"{stack_name}-data-managers-role-arn",
+            value=self.identitypool.authenticated_role.role_arn,
         )
 
     def _create_userpool(self) -> cognito.UserPool:
@@ -109,6 +115,24 @@ class AuthStack(Stack):
                     mapping_key="userpool",
                 )
             ],
+        )
+
+    def _grant_authenticated_role_principal(self, role_arn: str) -> None:
+        """Allow authenticated users from an authorized group to assume a role in the role's trust policy
+
+        Args:
+            role_arn (str): ARN of IAM role to be assumed by an authenticated user from an authorized group
+        """
+        
+        role = iam.Role.from_role_arn(
+            self,
+            "authenticated-role",
+            role_arn=role_arn,
+        )
+
+        role.grant(
+            self.identitypool.authenticated_role.grant_principal ,
+            "sts:AssumeRoleWithWebIdentity"
         )
 
     def _add_domain(self, userpool: cognito.UserPool) -> cognito.UserPoolDomain:
@@ -340,23 +364,17 @@ class AuthStack(Stack):
             precedence=self.group_precedence,
             role_arn=role.role_arn,
         )
-    
+
     def add_cognito_group_with_existing_role(
         self,
         group_name: str,
         description: str,
         role_arn: str,
     ) -> cognito.CfnUserPoolGroup:
-        """A method to create a user pool group with a pre-existing IAM role for authenticated users
 
-        Args:
-            group_name (str): Name to use for cognito user group
-            description (str): Additional user group description
-            role_arn (str): ARN of the in-account IAM role to be assumed by authenticated users in group
+        # Add identity pool to trust policy of role to be assumed by authenticated users in this group
+        self._grant_authenticated_role_principal(role_arn=role_arn)
 
-        Returns:
-            cognito.CfnUserPoolGroup
-        """
         return cognito.CfnUserPoolGroup(
             self,
             group_name,

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -340,3 +340,29 @@ class AuthStack(Stack):
             precedence=self.group_precedence,
             role_arn=role.role_arn,
         )
+    
+    def add_cognito_group_with_existing_role(
+        self,
+        group_name: str,
+        description: str,
+        role_arn: str,
+    ) -> cognito.CfnUserPoolGroup:
+        """A method to create a user pool group with a pre-existing IAM role for authenticated users
+
+        Args:
+            group_name (str): Name to use for cognito user group
+            description (str): Additional user group description
+            role_arn (str): ARN of the in-account IAM role to be assumed by authenticated users in group
+
+        Returns:
+            cognito.CfnUserPoolGroup
+        """
+        return cognito.CfnUserPoolGroup(
+            self,
+            group_name,
+            user_pool_id=self.userpool.user_pool_id,
+            description=description,
+            group_name=group_name,
+            precedence=self.group_precedence,
+            role_arn=role_arn,
+        )


### PR DESCRIPTION
# What
This PR adds an optional user group that can be deployed to assume an existing role.

# Why
The authenticated assume role auth flow allows us to grant data management credentials from a managed IAM role.

# How tested
1. Deployed cloud formation with a new data managers group and the ARN of an existing in-account VEDA Data Store access role. 
2. Added internal users to the data access group.
3. Tested AWS protected bucket access using temporary credentials obtained with both the PyPI cognito client and the temporary credentials notebook in this project.


I can share out the necessary identifiers to anyone interested in testing out the AWS credentials granted through the authenticated user group auth flow.