### PR TITLE
Allow `admin_user_password` authflow for programmatic client

### DIFF
--- a/infra/stack.py
+++ b/infra/stack.py
@@ -264,7 +264,7 @@ class AuthStack(Stack):
 
         client = self.userpool.add_client(
             service_id,
-            auth_flows=cognito.AuthFlow(user_password=True),
+            auth_flows=cognito.AuthFlow(user_password=True, admin_user_password=True),
             generate_secret=False,
             user_pool_client_name=name or service_id,
             # disable_o_auth=True,


### PR DESCRIPTION
The `/token` edpoint in veda-stac-ingestor needs the `admin_user_password` authflow to be able to fetch the token from username/password
This PR adds it to