### PR TITLE
Add OIDC, pre-commit, tags, git-deploy tags

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        language_version: python
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.4.2
+    hooks:
+      - id: isort
+        language_version: python
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.8.3
+    hooks:
+      - id: flake8
+        language_version: python
+        args: [--max-line-length=131]
+
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.812
+    hooks:
+      - id: mypy
+        language_version: python

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ User groups with pre defined roles can be creating by providing the existing rol
 2. CDK deploy change and note `veda-auth-stack-<STAGE>.userpoolid` in output. It will include the deployment region and a UUID, for example `us-west-2:11111111-1111-1111-1111-111111111111`
 3. Add a new statement to the role's trust policy in the AWS IAM console. Navigate to the desired role, choose `Trust Relationship` and select `edit`--be careful to preserve the existing trust statements when appending a new statement for this identity pool.
 
+## Using an OIDC provider
+To additionally deploy an OIDC provider (or use an existing one in the same account), set `OIDC_PROVIDER_URL` and `OIDC_THUMBPRINT` in environment configuration. For a github OIDC provider, the url is `token.actions.githubusercontent.com` and the thumbprint is `6938fd4d98bab03faadb97b34396831e3780aea1`.
+
 ### Example trust policy with appended statement for identity pool
 In this example, the second object conditionally allows authenticated users from this identity pool to assume the role with a web identity. Two conditions should be applied: `StringEquals` to restrict the statement to this identity pool and `ForAnyValue:StringLike` to restrict to authenticated users.
 
@@ -87,4 +90,3 @@ A streamlined version of the client can be installed with `pip install cognito_c
 
 # License
 This project is licensed under **Apache 2**, see the [LICENSE](LICENSE) file for more details.
-

--- a/app.py
+++ b/app.py
@@ -95,11 +95,14 @@ stack.add_service_client(
 
 # Generate an OIDC provider, allowing CI workers to assume roles in the account
 
-stack.add_oidc_provider(
-    f"veda-oidc-provider-{config.stage}",
-    config.oidc_provider_url,
-    config.oidc_thumbprint,
-)
+oidc_thumbprint = config.oidc_thumbprint
+oidc_provider_url = config.oidc_provider_url
+if oidc_thumbprint and oidc_provider_url:
+    stack.add_oidc_provider(
+        f"veda-oidc-provider-{config.stage}",
+        oidc_provider_url,
+        oidc_thumbprint,
+    )
 
 # Programmatic Clients
 stack.add_programmatic_client("veda-sdk")

--- a/app.py
+++ b/app.py
@@ -1,31 +1,37 @@
 #!/usr/bin/env python3
 import os
+import subprocess
 
 import aws_cdk as cdk
 
-from infra.stack import AuthStack, BucketPermissions
 from config import Config
+from infra.stack import AuthStack, BucketPermissions
 
 config = Config(_env_file=os.environ.get("ENV_FILE", ".env"))
+git_sha = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+try:
+    git_tag = subprocess.check_output(["git", "describe", "--tags"]).decode().strip()
+except subprocess.CalledProcessError:
+    git_tag = "no-tag"
+
+tags = {
+    "Project": "veda",
+    "Owner": config.owner,
+    "Client": "nasa-impact",
+    "Stack": config.stage,
+    "GitCommit": git_sha,
+    "GitTag": git_tag,
+}
 
 app = cdk.App()
-stack = AuthStack(
-    app,
-    f"veda-auth-stack-{config.stage}",
-    tags={
-        "Project": "veda",
-        "Owner": config.owner,
-        "Client": "nasa-impact",
-        "Stack": config.stage,
-    },
-)
+stack = AuthStack(app, f"veda-auth-stack-{config.stage}")
 
 # Create a data managers group in user pool if data managers role is provided
 if data_managers_role_arn := config.data_managers_role_arn:
     stack.add_cognito_group_with_existing_role(
         "veda-data-store-managers",
         "Authenticated users assume read write veda data access role",
-        role_arn=data_managers_role_arn
+        role_arn=data_managers_role_arn,
     )
 
 # Create Groups
@@ -87,10 +93,21 @@ stack.add_service_client(
     ],
 )
 
+# Generate an OIDC provider, allowing CI workers to assume roles in the account
+
+stack.add_oidc_provider(
+    f"veda-oidc-provider-{config.stage}",
+    config.oidc_provider_url,
+    config.oidc_thumbprint,
+)
+
 # Programmatic Clients
 stack.add_programmatic_client("veda-sdk")
 
 # Frontend Clients
 # stack.add_frontend_client('veda-dashboard')
+
+for key, value in tags.items():
+    cdk.Tags.of(stack).add(key, value)
 
 app.synth()

--- a/config.py
+++ b/config.py
@@ -28,3 +28,13 @@ class Config(pydantic.BaseSettings):
         None,
         description="ARN of role to be assumed by authenticated users in data managers group.",
     )
+
+    oidc_provider_url: str = pydantic.Field(
+        "token.actions.githubusercontent.com",
+        description="URL of OIDC provider to use for CI workers.",
+    )
+
+    oidc_thumbprint: str = pydantic.Field(
+        "6938fd4d98bab03faadb97b34396831e3780aea1",
+        description="Thumbprint of OIDC provider to use for CI workers.",
+    )

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 from getpass import getuser
+from typing import Optional
 
 import pydantic
 
@@ -29,12 +30,12 @@ class Config(pydantic.BaseSettings):
         description="ARN of role to be assumed by authenticated users in data managers group.",
     )
 
-    oidc_provider_url: str = pydantic.Field(
-        "token.actions.githubusercontent.com",
+    oidc_provider_url: Optional[str] = pydantic.Field(
+        None,
         description="URL of OIDC provider to use for CI workers.",
     )
 
-    oidc_thumbprint: str = pydantic.Field(
-        "6938fd4d98bab03faadb97b34396831e3780aea1",
+    oidc_thumbprint: Optional[str] = pydantic.Field(
+        None,
         description="Thumbprint of OIDC provider to use for CI workers.",
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ boto3-stubs[cognito-idp,cognito-identity]
 flake8==4.0.1
 click==8.1.3
 requests==2.28.0
+pre-commit==3.0.4


### PR DESCRIPTION
### What

- Adds CDK for provisioning OIDC provider, which can be used by other repos to allow CICD actions to assume AWS roles
- Adds pre-commit to repo
- Adds tags to all veda-auth resources
- All resources are tagged with the repo's most recent commit SHA and (if present) current tag, to allow deployed resources to be identified with their current version

### Why

- We want to move secrets and env vars into AWS (as we've done for `veda-backend`), and OIDC is the easiest and best way to allow Github Actions to retrieve those secrets.
- We want consistent pre-commit rules in our repos
- We want to bring more resources in line with our AWS tagging policies
- It's sometimes unclear which versions of our code are deployed to certain environments. Better tags will allow us to better identify which features are live in different environments.

