### PR TITLE
Add configurable role access to credential flow secrets

### DIFF
--- a/app.py
+++ b/app.py
@@ -104,6 +104,8 @@ if oidc_thumbprint and oidc_provider_url:
         oidc_thumbprint,
     )
 
+
+
 # Programmatic Clients
 stack.add_programmatic_client("veda-sdk")
 

--- a/config.py
+++ b/config.py
@@ -1,5 +1,5 @@
 from getpass import getuser
-from typing import Optional
+from typing import Optional, Sequence
 
 import pydantic
 
@@ -38,4 +38,9 @@ class Config(pydantic.BaseSettings):
     oidc_thumbprint: Optional[str] = pydantic.Field(
         None,
         description="Thumbprint of OIDC provider to use for CI workers.",
+    )
+
+    secret_role_access: Sequence[str] = pydantic.Field(
+        [],
+        description="Optional list of role ARNs with access to credential flow secrets"
     )


### PR DESCRIPTION
Draft PR - comparable `cognito-client` PR to follow

Allows a configurable list of roles (default None) to read a secret containing client IDs, auth flow parameters to programmatic clients. Allows a user with an authorized role to attempt to log in to the user pool without knowing the client ID.