### PR TITLE
Make MCP ready

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -87,4 +87,6 @@ jobs:
         run: ./scripts/sync-env.sh veda-auth-mcp-dev
 
       - name: Deploy
+        env:
+          AWS_DEFAULT_REGION: us-west-2
         run: cdk deploy --all --require-approval never --outputs-file ${HOME}/cdk-outputs.json

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -76,8 +76,7 @@ jobs:
         with:
           python-version: "3.10"
           cache: "pip"
-          cache-dependency-path: |
-              ${{ inputs.dir }}/requirements.txt
+          cache-dependency-path: requirements.txt
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -60,12 +60,12 @@ jobs:
       - name: Install node and related deps
         uses: actions/setup-node@v3
         with:
-        node-version: 17.3.0
+          node-version: 17.3.0
 
       - uses: actions/cache@v3
         with:
-        path: ~/.npm
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install AWS CDK
         shell: bash

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -89,4 +89,5 @@ jobs:
       - name: Deploy
         env:
           AWS_DEFAULT_REGION: us-west-2
+          CDK_DEFAULT_REGION: us-west-2
         run: cdk deploy --all --require-approval never --outputs-file ${HOME}/cdk-outputs.json

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,91 @@
+name: CICD 🚀
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - production
+      - make-mcp-ready
+
+jobs:
+  define-environment:
+    name: Set ✨ environment ✨ based on the branch 🌳
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set the environment
+        id: define_environment
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "env_name=staging" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref }}" = "refs/heads/dev" ]; then
+            echo "env_name=development" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref }}" = "refs/heads/production" ]; then
+            echo "env_name=production" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref }}" = "refs/heads/make-mcp-ready" ]; then
+            echo "env_name=mcp-dev" >> $GITHUB_OUTPUT
+          fi
+      - name: Print the environment
+        run: echo "The environment is ${{ steps.define_environment.outputs.env_name }}"
+
+    outputs:
+      env_name: ${{ steps.define_environment.outputs.env_name }}
+
+  deploy:
+    name: Deploy to ${{ needs.define-environment.outputs.env_name }} 🚀
+    runs-on: ubuntu-latest
+    if: ${{ needs.define-environment.outputs.env_name }}
+    needs: [define-environment]
+    environment: ${{ needs.define-environment.outputs.env_name }}
+    concurrency: ${{ needs.define-environment.outputs.env_name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: "true"
+          submodules: "recursive"
+        
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
+          role-session-name: "veda-auth-github-${{ needs.define-environment.outputs.env_name }}-deployment"
+          aws-region: "us-west-2"
+
+      - name: Install node and related deps
+        uses: actions/setup-node@v3
+        with:
+        node-version: 17.3.0
+
+      - uses: actions/cache@v3
+        with:
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install AWS CDK
+        shell: bash
+        run: npm install -g aws-cdk@2
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: |
+              ${{ inputs.dir }}/requirements.txt
+
+      - name: Install python dependencies
+        run: |
+          pip install \
+            -r requirements.txt \
+
+      - name: Get relevant environment configuration from aws secrets
+        run: ./scripts/sync-env.sh veda-auth-mcp-dev
+
+      - name: Deploy
+        run: cdk deploy --all --require-approval never --outputs-file ${HOME}/cdk-outputs.json

--- a/app.py
+++ b/app.py
@@ -25,6 +25,14 @@ tags = {
 app = cdk.App()
 stack = AuthStack(app, f"veda-auth-stack-{app_settings.stage}", app_settings)
 
+# Create an data managers group in user pool if data managers role is provided (legacy stack support)
+if data_managers_role_arn := app_settings.data_managers_role_arn:
+    stack.add_cognito_group_with_existing_role(
+        "veda-data-store-managers",
+        "Authenticated users assume read write veda data access role",
+        role_arn=data_managers_role_arn,
+    )
+
 # Create Groups
 if app_settings.cognito_groups:
     # Create a data managers group in user pool if data managers role is provided

--- a/app.py
+++ b/app.py
@@ -4,10 +4,10 @@ import subprocess
 
 import aws_cdk as cdk
 
-from config import Config
 from infra.stack import AuthStack, BucketPermissions
 
-config = Config(_env_file=os.environ.get("ENV_FILE", ".env"))
+from config import app_settings
+
 git_sha = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
 try:
     git_tag = subprocess.check_output(["git", "describe", "--tags"]).decode().strip()
@@ -16,60 +16,61 @@ except subprocess.CalledProcessError:
 
 tags = {
     "Project": "veda",
-    "Owner": config.owner,
+    "Owner": app_settings.owner,
     "Client": "nasa-impact",
-    "Stack": config.stage,
+    "Stack": app_settings.stage,
     "GitCommit": git_sha,
     "GitTag": git_tag,
 }
 
 app = cdk.App()
-stack = AuthStack(app, f"veda-auth-stack-{config.stage}")
-
-# Create a data managers group in user pool if data managers role is provided
-if data_managers_role_arn := config.data_managers_role_arn:
-    stack.add_cognito_group_with_existing_role(
-        "veda-data-store-managers",
-        "Authenticated users assume read write veda data access role",
-        role_arn=data_managers_role_arn,
-    )
+stack = AuthStack(app, f"veda-auth-stack-{app_settings.stage}")
 
 # Create Groups
-stack.add_cognito_group(
-    "veda-staging-writers",
-    "Users that have read/write-access to the VEDA store and staging datastore",
-    {
-        "veda-data-store-dev": BucketPermissions.read_write,
-        "veda-data-store": BucketPermissions.read_write,
-        "veda-data-store-staging": BucketPermissions.read_write,
-    },
-)
-stack.add_cognito_group(
-    "veda-writers",
-    "Users that have read/write-access to the VEDA store",
-    {
-        "veda-data-store-dev": BucketPermissions.read_write,
-        "veda-data-store": BucketPermissions.read_write,
-    },
-)
+if app_settings.cognito_groups:
+    # Create a data managers group in user pool if data managers role is provided
+    if data_managers_role_arn := app_settings.data_managers_role_arn:
+        stack.add_cognito_group_with_existing_role(
+            "veda-data-store-managers",
+            "Authenticated users assume read write veda data access role",
+            role_arn=data_managers_role_arn,
+        )
 
-stack.add_cognito_group(
-    "veda-staging-readers",
-    "Users that have read-access to the VEDA store and staging data store",
-    {
-        "veda-data-store-dev": BucketPermissions.read_only,
-        "veda-data-store": BucketPermissions.read_only,
-        "veda-data-store-staging": BucketPermissions.read_only,
-    },
-)
-# TODO: Should this be the default IAM role for the user group?
-stack.add_cognito_group(
-    "veda-readers",
-    "Users that have read-access to the VEDA store",
-    {
-        "veda-data-store": BucketPermissions.read_only,
-    },
-)
+    stack.add_cognito_group(
+        "veda-staging-writers",
+        "Users that have read/write-access to the VEDA store and staging datastore",
+        {
+            "veda-data-store-dev": BucketPermissions.read_write,
+            "veda-data-store": BucketPermissions.read_write,
+            "veda-data-store-staging": BucketPermissions.read_write,
+        },
+    )
+    stack.add_cognito_group(
+        "veda-writers",
+        "Users that have read/write-access to the VEDA store",
+        {
+            "veda-data-store-dev": BucketPermissions.read_write,
+            "veda-data-store": BucketPermissions.read_write,
+        },
+    )
+
+    stack.add_cognito_group(
+        "veda-staging-readers",
+        "Users that have read-access to the VEDA store and staging data store",
+        {
+            "veda-data-store-dev": BucketPermissions.read_only,
+            "veda-data-store": BucketPermissions.read_only,
+            "veda-data-store-staging": BucketPermissions.read_only,
+        },
+    )
+    # TODO: Should this be the default IAM role for the user group?
+    stack.add_cognito_group(
+        "veda-readers",
+        "Users that have read-access to the VEDA store",
+        {
+            "veda-data-store": BucketPermissions.read_only,
+        },
+    )
 
 # Generate a resource server (ie something to protect behind auth) with scopes
 # (permissions that we can grant to users/services).
@@ -95,11 +96,11 @@ stack.add_service_client(
 
 # Generate an OIDC provider, allowing CI workers to assume roles in the account
 
-oidc_thumbprint = config.oidc_thumbprint
-oidc_provider_url = config.oidc_provider_url
+oidc_thumbprint = app_settings.oidc_thumbprint
+oidc_provider_url = app_settings.oidc_provider_url
 if oidc_thumbprint and oidc_provider_url:
     stack.add_oidc_provider(
-        f"veda-oidc-provider-{config.stage}",
+        f"veda-oidc-provider-{app_settings.stage}",
         oidc_provider_url,
         oidc_thumbprint,
     )

--- a/app.py
+++ b/app.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import os
 import subprocess
 
 import aws_cdk as cdk
@@ -24,7 +23,7 @@ tags = {
 }
 
 app = cdk.App()
-stack = AuthStack(app, f"veda-auth-stack-{app_settings.stage}")
+stack = AuthStack(app, f"veda-auth-stack-{app_settings.stage}", app_settings)
 
 # Create Groups
 if app_settings.cognito_groups:

--- a/config.py
+++ b/config.py
@@ -50,7 +50,16 @@ class Config(pydantic.BaseSettings):
     # Since MCP doesn't allow creating identity pools, setting this as optional
     cognito_groups: Optional[bool] = pydantic.Field(
         True,
-        description="Where to create cognito groups with bucket access permissions",
+        description="whether to create cognito groups with bucket access permissions",
+    )
+
+    identity_pool_id: Optional[str] = pydantic.Field(
+        "",
+        description="If creating cognito groups for access control, identity_pool id to associate",
+    )
+
+    user_pool_id: Optional[str] = pydantic.Field(
+        "", description="The user pool id to use for user management"
     )
 
 

--- a/config.py
+++ b/config.py
@@ -1,6 +1,8 @@
 from getpass import getuser
 from typing import Optional
 
+import os
+
 import pydantic
 
 
@@ -39,3 +41,17 @@ class Config(pydantic.BaseSettings):
         None,
         description="Thumbprint of OIDC provider to use for CI workers.",
     )
+
+    permissions_boundary_policy_name: Optional[str] = pydantic.Field(
+        None,
+        description="Name of IAM policy to define stack permissions boundary",
+    )
+
+    # Since MCP doesn't allow creating identity pools, setting this as optional
+    cognito_groups: Optional[bool] = pydantic.Field(
+        True,
+        description="Where to create cognito groups with bucket access permissions",
+    )
+
+
+app_settings = Config(_env_file=os.environ.get("ENV_FILE", ".env"))

--- a/config.py
+++ b/config.py
@@ -53,7 +53,7 @@ class Config(pydantic.BaseSettings):
         description="whether to create cognito groups with bucket access permissions",
     )
 
-    identity_pool_id: Optional[str] = pydantic.Field(
+    identity_pool_arn: Optional[str] = pydantic.Field(
         "",
         description="If creating cognito groups for access control, identity_pool id to associate",
     )

--- a/infra/permission_boundary.py
+++ b/infra/permission_boundary.py
@@ -1,0 +1,55 @@
+from typing import Union
+
+import jsii
+from aws_cdk import aws_iam, IAspect
+from constructs import IConstruct
+from jsii._reference_map import _refs
+from jsii._utils import Singleton
+
+
+@jsii.implements(IAspect)
+class PermissionBoundaryAspect:
+    """
+    This aspect finds all aws_iam.Role objects in a node (ie. CDK stack) and sets permission boundary to the given ARN.
+    """
+
+    def __init__(self, permission_boundary: Union[aws_iam.ManagedPolicy, str]) -> None:
+        """
+        :param permission_boundary: Either aws_iam.ManagedPolicy object or managed policy's ARN string
+        """
+        self.permission_boundary = permission_boundary
+
+    def visit(self, construct_ref: IConstruct) -> None:
+        """
+        construct_ref only contains a string reference to an object. To get the actual object, we need to resolve it using JSII mapping.
+        :param construct_ref: ObjRef object with string reference to the actual object.
+        :return: None
+        """
+        if isinstance(construct_ref, jsii._kernel.ObjRef) and hasattr(
+            construct_ref, "ref"
+        ):
+            kernel = Singleton._instances[
+                jsii._kernel.Kernel
+            ]  # The same object is available as: jsii.kernel
+            resolve = _refs.resolve(kernel, construct_ref)
+        else:
+            resolve = construct_ref
+
+        def _walk(obj):
+            if isinstance(obj, aws_iam.Role):
+                cfn_role = obj.node.find_child("Resource")
+                policy_arn = (
+                    self.permission_boundary
+                    if isinstance(self.permission_boundary, str)
+                    else self.permission_boundary.managed_policy_arn
+                )
+                cfn_role.add_property_override("PermissionsBoundary", policy_arn)
+            else:
+                if hasattr(obj, "permissions_node"):
+                    for c in obj.permissions_node.children:
+                        _walk(c)
+                if hasattr(obj, "node") and obj.node.children:
+                    for c in obj.node.children:
+                        _walk(c)
+
+        _walk(resolve)

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -51,9 +51,9 @@ class AuthStack(Stack):
         if app_settings.cognito_groups:
             self._group_precedence = 0
 
-            if app_settings.identity_pool_id:
-                self.identitypool = cognito_id_pool.IdentityPool.from_identity_pool_id(
-                    self, "identity-pool", app_settings.identity_pool_id
+            if app_settings.identity_pool_arn:
+                self.identitypool = cognito_id_pool.IdentityPool.from_identity_pool_arn(
+                    self, "identity-pool", app_settings.identity_pool_arn
                 )
             else:
                 auth_provider_client = self.add_programmatic_client(
@@ -76,18 +76,18 @@ class AuthStack(Stack):
                 export_name=f"{stack_name}-identitypool-arn",
                 value=self.identitypool.identity_pool_arn,
             )
-            CfnOutput(
-                self,
-                "identitypool_client_id",
-                export_name=f"{stack_name}-client-id",
-                value=auth_provider_client.user_pool_client_id,
-            )
-            CfnOutput(
-                self,
-                "identitypool_data_managers_role_arn",
-                export_name=f"{stack_name}-data-managers-role-arn",
-                value=self.identitypool.authenticated_role.role_arn,
-            )
+            # CfnOutput(
+            #     self,
+            #     "identitypool_client_id",
+            #     export_name=f"{stack_name}-client-id",
+            #     value=auth_provider_client.user_pool_client_id,
+            # )
+            # CfnOutput(
+            #     self,
+            #     "identitypool_data_managers_role_arn",
+            #     export_name=f"{stack_name}-data-managers-role-arn",
+            #     value=self.identitypool.authenticated_role.role_arn,
+            # )
 
     def _create_userpool(self) -> cognito.UserPool:
         return cognito.UserPool(

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -53,7 +53,7 @@ class AuthStack(Stack):
 
             if app_settings.identity_pool_id:
                 self.identitypool = cognito_id_pool.IdentityPool.from_identity_pool_id(
-                    self, "identity-pool", app_settings.identity_pool_id_id
+                    self, "identity-pool", app_settings.identity_pool_id
                 )
             else:
                 auth_provider_client = self.add_programmatic_client(

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -10,6 +10,9 @@ from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_secretsmanager as secretsmanager
 from aws_cdk import custom_resources as cr
 from constructs import Construct
+from aws_cdk import Aspects
+
+from config import Config
 
 
 class BucketPermissions(str, Enum):
@@ -18,56 +21,65 @@ class BucketPermissions(str, Enum):
 
 
 class AuthStack(Stack):
-    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+    def __init__(
+        self, scope: Construct, construct_id: str, app_settings: Config, **kwargs
+    ) -> None:
         super().__init__(scope, construct_id, **kwargs)
+
+        if app_settings.permissions_boundary_policy_name:
+            permission_boundary_policy = iam.ManagedPolicy.from_managed_policy_name(
+                self,
+                "permission-boundary",
+                app_settings.permissions_boundary_policy_name,
+            )
+            iam.PermissionsBoundary.of(self).apply(permission_boundary_policy)
+
+            from infra.permission_boundary import PermissionBoundaryAspect
+
+            Aspects.of(self).add(PermissionBoundaryAspect(permission_boundary_policy))
 
         self.userpool = self._create_userpool()
         self.domain = self._add_domain(self.userpool)
-        auth_provider_client = self.add_programmatic_client(
-            "cognito-identity-pool-auth-provider",
-            name="Identity Pool Authentication Provider",
-        )
-        self.identitypool = self._create_identity_pool(
-            userpool=self.userpool,
-            auth_provider_client=auth_provider_client,
-        )
-
-        self._group_precedence = 0
 
         stack_name = Stack.of(self).stack_name
-        CfnOutput(
-            self,
-            "userpool_id",
-            export_name=f"{stack_name}-userpool-id",
-            value=self.userpool.user_pool_id,
-        )
-        CfnOutput(
-            self,
-            "identitypool_id",
-            export_name=f"{stack_name}-identitypool-id",
-            value=self.identitypool.identity_pool_id,
-        )
-        CfnOutput(
-            self,
-            "identitypool_arn",
-            export_name=f"{stack_name}-identitypool-arn",
-            value=self.identitypool.identity_pool_arn,
-        )
-        CfnOutput(
-            self,
-            "identitypool_client_id",
-            export_name=f"{stack_name}-client-id",
-            value=auth_provider_client.user_pool_client_id,
-        )
-        CfnOutput(
-            self,
-            "identitypool_data_managers_role_arn",
-            export_name=f"{stack_name}-data-managers-role-arn",
-            value=self.identitypool.authenticated_role.role_arn,
-        )
+
+        if app_settings.cognito_groups:
+            self._group_precedence = 0
+
+            auth_provider_client = self.add_programmatic_client(
+                "cognito-identity-pool-auth-provider",
+                name="Identity Pool Authentication Provider",
+            )
+            self.identitypool = self._create_identity_pool(
+                userpool=self.userpool,
+                auth_provider_client=auth_provider_client,
+            )
+            CfnOutput(
+                self,
+                "identitypool_id",
+                export_name=f"{stack_name}-identitypool-id",
+                value=self.identitypool.identity_pool_id,
+            )
+            CfnOutput(
+                self,
+                "identitypool_arn",
+                export_name=f"{stack_name}-identitypool-arn",
+                value=self.identitypool.identity_pool_arn,
+            )
+            CfnOutput(
+                self,
+                "identitypool_client_id",
+                export_name=f"{stack_name}-client-id",
+                value=auth_provider_client.user_pool_client_id,
+            )
+            CfnOutput(
+                self,
+                "identitypool_data_managers_role_arn",
+                export_name=f"{stack_name}-data-managers-role-arn",
+                value=self.identitypool.authenticated_role.role_arn,
+            )
 
     def _create_userpool(self) -> cognito.UserPool:
-
         return cognito.UserPool(
             self,
             "userpool",
@@ -86,7 +98,6 @@ class AuthStack(Stack):
         userpool: cognito.UserPool,
         auth_provider_client: cognito.UserPoolClient,
     ) -> cognito_id_pool.IdentityPool:
-
         userpool_provider = cognito_id_pool.UserPoolAuthenticationProvider(
             user_pool=userpool,
             user_pool_client=auth_provider_client,
@@ -156,7 +167,6 @@ class AuthStack(Stack):
         self,
         client: cognito.UserPoolClient,
     ) -> str:
-
         describe_cognito_user_pool_client = cr.AwsCustomResource(
             self,
             f"describe-{client.to_string()}",
@@ -225,7 +235,6 @@ class AuthStack(Stack):
         oidc_domain: str,
         oidc_thumbprint: str,
     ) -> iam.OpenIdConnectProvider:
-
         # OIDC providers are unique per account/url pair. If the provider already exists,
         # we can just reuse it. Otherwise, we need to create it.
 
@@ -297,7 +306,6 @@ class AuthStack(Stack):
         service_id: str,
         name: Optional[str] = None,
     ) -> cognito.UserPoolClient:
-
         client = self.userpool.add_client(
             service_id,
             auth_flows=cognito.AuthFlow(user_password=True, admin_user_password=True),
@@ -367,7 +375,6 @@ class AuthStack(Stack):
         description: str,
         bucket_permissions: Dict[str, BucketPermissions],
     ) -> cognito.CfnUserPoolGroup:
-
         role = iam.Role(
             self,
             f"{group_name}_role",
@@ -407,7 +414,6 @@ class AuthStack(Stack):
         description: str,
         role_arn: str,
     ) -> cognito.CfnUserPoolGroup:
-
         # Add identity pool to trust policy of authenticated users role
         self._grant_authenticated_role_principal(role_arn=role_arn)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ flake8==4.0.1
 click==8.1.3
 requests==2.28.0
 pre-commit==3.0.4
+pydantic[dotenv]

--- a/scripts/sync-env.sh
+++ b/scripts/sync-env.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Use this script to load environment variables for a deployment from AWS Secrets
+
+echo Loading environment secrets from $1
+aws secretsmanager get-secret-value --secret-id $1 --query SecretString --output text | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' > .env

--- a/scripts/sync-env.sh
+++ b/scripts/sync-env.sh
@@ -3,3 +3,4 @@
 
 echo Loading environment secrets from $1
 aws secretsmanager get-secret-value --secret-id $1 --query SecretString --output text | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' > .env
+cat .env


### PR DESCRIPTION
# Changes
- Add options for providing already existing identity pool and user pools (mcp needs a ticket to create an identity pool, and since the identity pool needs to be configured with the userpool as authentication provider, it's easier if those are already created)
- Make creating cognito pools optional 