### PR TITLE
Include veda deploy action

### DIFF
--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -1,0 +1,66 @@
+name: Deploy
+
+inputs:
+  env_aws_secret_name:
+    required: true
+    type: string
+  dir:
+    required: false
+    type: string
+    default: "."
+  script_path:
+    required: true
+    type: string
+
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install node and related deps
+      uses: actions/setup-node@v3
+      with:
+        node-version: 17.3.0
+
+    - uses: actions/cache@v3
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+    - name: Install AWS CDK
+      shell: bash
+      run: npm install -g aws-cdk@2
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+        cache: "pip"
+        cache-dependency-path: |
+          ${{ inputs.dir }}/requirements.txt
+
+    - name: Install python dependencies
+      shell: bash
+      working-directory: ${{ inputs.dir }}
+      run: |
+        pip install \
+          -r requirements.txt \
+
+    - name: Get relevant environment configuration from aws secrets
+      shell: bash
+      working-directory: ${{ inputs.dir }}
+      env:
+        AWS_DEFAULT_REGION: us-west-2
+      run: |
+        if [[ -z "${{ inputs.script_path }}" ]]; then
+        ./scripts/sync-env.sh ${{ inputs.env_aws_secret_name }}
+        else
+        python ${{ inputs.script_path }} --secret-id ${{ inputs.env_aws_secret_name }}
+        fi
+
+    - name: Deploy
+      id: deploy_auth_stack
+      shell: bash
+      working-directory: ${{ inputs.dir }}
+      run: |
+        cdk deploy --all --require-approval never --outputs-file ${HOME}/cdk-outputs.json

--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -12,8 +12,6 @@ inputs:
     required: true
     type: string
 
-
-
 runs:
   using: "composite"
   steps:
@@ -51,16 +49,11 @@ runs:
       working-directory: ${{ inputs.dir }}
       env:
         AWS_DEFAULT_REGION: us-west-2
-      run: |
-        if [[ -z "${{ inputs.script_path }}" ]]; then
-        ./scripts/sync-env.sh ${{ inputs.env_aws_secret_name }}
-        else
-        python ${{ inputs.script_path }} --secret-id ${{ inputs.env_aws_secret_name }}
-        fi
+      run: ./scripts/get-env.sh ${{ inputs.env_aws_secret_name }}
 
     - name: Deploy
       id: deploy_auth_stack
       shell: bash
       working-directory: ${{ inputs.dir }}
       run: |
-        cdk deploy --all --require-approval never --outputs-file ${HOME}/cdk-outputs.json
+        cdk deploy --all --require-approval never

--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -56,4 +56,4 @@ runs:
       shell: bash
       working-directory: ${{ inputs.dir }}
       run: |
-        cdk deploy --all --require-approval never
+        cdk deploy --all --require-approval never --outputs-file ${HOME}/cdk-outputs.json

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,9 +7,7 @@ permissions:
 on:
   push:
     branches:
-      - main
-      - dev
-      - production
+      - make-mcp-ready
 
 jobs:
   define-environment:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,7 +10,6 @@ on:
       - main
       - dev
       - production
-      - make-mcp-ready
 
 jobs:
   define-environment:
@@ -22,12 +21,13 @@ jobs:
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "env_name=staging" >> $GITHUB_OUTPUT
+            echo "secret_name=veda-auth-staging" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref }}" = "refs/heads/dev" ]; then
             echo "env_name=development" >> $GITHUB_OUTPUT
+            echo "secret_name=veda-auth-dev" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref }}" = "refs/heads/production" ]; then
             echo "env_name=production" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref }}" = "refs/heads/make-mcp-ready" ]; then
-            echo "env_name=mcp-dev" >> $GITHUB_OUTPUT
+            echo "secret_name=veda-auth-production" >> $GITHUB_OUTPUT
           fi
       - name: Print the environment
         run: echo "The environment is ${{ steps.define_environment.outputs.env_name }}"
@@ -50,12 +50,12 @@ jobs:
           lfs: "true"
           submodules: "recursive"
         
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+      - name: Configure awscli
+        uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
-          role-session-name: "veda-auth-github-${{ needs.define-environment.outputs.env_name }}-deployment"
-          aws-region: "us-west-2"
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
 
       - name: Install node and related deps
         uses: actions/setup-node@v3
@@ -83,11 +83,11 @@ jobs:
           pip install \
             -r requirements.txt \
 
-      - name: Get relevant environment configuration from aws secrets
-        run: ./scripts/sync-env.sh veda-auth-mcp-dev
+      - name: Get environment configuration from aws secrets
+        run: ./scripts/get-env.sh  ${{ needs.define-environment.outputs.secret_name }}
 
       - name: Deploy
         env:
           AWS_DEFAULT_REGION: us-west-2
           CDK_DEFAULT_REGION: us-west-2
-        run: cdk deploy --all --require-approval never --outputs-file ${HOME}/cdk-outputs.json
+        run: cdk deploy --all --require-approval never

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,50 @@
+name: Pull Request - Preview CDK Diff
+
+on: [pull_request]
+
+jobs:
+  predeploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 17
+
+      - name: Configure awscli
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install CDK
+        run: npm install -g aws-cdk@2
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key:  ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
+
+      - name: Install python dependencies
+        run: |
+            pip install -r requirements.txt
+
+      - name: Get environment configuration for target branch
+        run: |
+          ./scripts/get-env.sh "veda-auth-uah-env"
+      - name: Pre deployment CDK diff
+        run: |
+          echo $STAGE
+          cdk diff --outputs-file ${HOME}/cdk-outputs.json

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__
 .cdk.staging
 cdk.out
 *.env
+.ipynb_checkpoints
+

--- a/app.py
+++ b/app.py
@@ -7,21 +7,6 @@ from infra.stack import AuthStack, BucketPermissions
 
 from config import app_settings
 
-git_sha = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
-try:
-    git_tag = subprocess.check_output(["git", "describe", "--tags"]).decode().strip()
-except subprocess.CalledProcessError:
-    git_tag = "no-tag"
-
-tags = {
-    "Project": "veda",
-    "Owner": app_settings.owner,
-    "Client": "nasa-impact",
-    "Stack": app_settings.stage,
-    "GitCommit": git_sha,
-    "GitTag": git_tag,
-}
-
 app = App()
 if app_settings.bootstrap_qualifier:
     app.node.set_context(
@@ -122,6 +107,21 @@ stack.add_programmatic_client("veda-sdk")
 
 # Frontend Clients
 # stack.add_frontend_client('veda-dashboard')
+
+git_sha = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+try:
+    git_tag = subprocess.check_output(["git", "describe", "--tags"]).decode().strip()
+except subprocess.CalledProcessError:
+    git_tag = "no-tag"
+
+tags = {
+    "Project": "veda",
+    "Owner": app_settings.owner,
+    "Client": "nasa-impact",
+    "Stack": app_settings.stage,
+    "GitCommit": git_sha,
+    "GitTag": git_tag,
+}
 
 for key, value in tags.items():
     Tags.of(stack).add(key, value)

--- a/app.py
+++ b/app.py
@@ -19,23 +19,15 @@ stack = AuthStack(
 )
 
 # Create an data managers group in user pool if data managers role is provided (legacy stack support)
-if data_managers_role_arn := app_settings.data_managers_role_arn:
+if app_settings.data_managers_group and app_settings.data_managers_role_arn:
     stack.add_cognito_group_with_existing_role(
         "veda-data-store-managers",
         "Authenticated users assume read write veda data access role",
-        role_arn=data_managers_role_arn,
+        role_arn=app_settings.data_managers_role_arn,
     )
 
-# Create Groups
+# Create Groups if Configured
 if app_settings.cognito_groups:
-    # Create a data managers group in user pool if data managers role is provided
-    if data_managers_role_arn := app_settings.data_managers_role_arn:
-        stack.add_cognito_group_with_existing_role(
-            "veda-data-store-managers",
-            "Authenticated users assume read write veda data access role",
-            role_arn=data_managers_role_arn,
-        )
-
     stack.add_cognito_group(
         "veda-staging-writers",
         "Users that have read/write-access to the VEDA store and staging datastore",

--- a/app.py
+++ b/app.py
@@ -23,6 +23,11 @@ tags = {
 }
 
 app = cdk.App()
+if app_settings.bootstrap_qualifier:
+    app.node.set_context(
+        "@aws-cdk/core:bootstrapQualifier", app_settings.bootstrap_qualifier
+    )
+
 stack = AuthStack(app, f"veda-auth-stack-{app_settings.stage}", app_settings)
 
 # Create an data managers group in user pool if data managers role is provided (legacy stack support)

--- a/app.py
+++ b/app.py
@@ -1,19 +1,22 @@
 #!/usr/bin/env python3
 import subprocess
 
-from aws_cdk import App, Tags
+from aws_cdk import App, Tags, DefaultStackSynthesizer
 
 from infra.stack import AuthStack, BucketPermissions
 
 from config import app_settings
 
 app = App()
-if app_settings.bootstrap_qualifier:
-    app.node.set_context(
-        "@aws-cdk/core:bootstrapQualifier", app_settings.bootstrap_qualifier
-    )
 
-stack = AuthStack(app, f"veda-auth-stack-{app_settings.stage}", app_settings)
+stack = AuthStack(
+    app, 
+    f"veda-auth-stack-{app_settings.stage}", 
+    app_settings,
+    synthesizer=DefaultStackSynthesizer(
+        qualifier=app_settings.bootstrap_qualifier
+    )
+)
 
 # Create an data managers group in user pool if data managers role is provided (legacy stack support)
 if data_managers_role_arn := app_settings.data_managers_role_arn:

--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import subprocess
 
-import aws_cdk as cdk
+from aws_cdk import App, Tags
 
 from infra.stack import AuthStack, BucketPermissions
 
@@ -22,7 +22,7 @@ tags = {
     "GitTag": git_tag,
 }
 
-app = cdk.App()
+app = App()
 if app_settings.bootstrap_qualifier:
     app.node.set_context(
         "@aws-cdk/core:bootstrapQualifier", app_settings.bootstrap_qualifier
@@ -124,6 +124,6 @@ stack.add_programmatic_client("veda-sdk")
 # stack.add_frontend_client('veda-dashboard')
 
 for key, value in tags.items():
-    cdk.Tags.of(stack).add(key, value)
+    Tags.of(stack).add(key, value)
 
 app.synth()

--- a/cdk.json
+++ b/cdk.json
@@ -1,31 +1,3 @@
 {
-  "app": "python3 app.py",
-  "watch": {
-    "include": [
-      "**"
-    ],
-    "exclude": [
-      "README.md",
-      "cdk*.json",
-      "requirements*.txt",
-      "source.bat",
-      "**/*.pyc",
-      "**/*.tmp",
-      "**/__pycache__",
-      "tests",
-      "scripts"
-    ]
-  },
-  "context": {
-    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:stackRelativeExports": true,
-    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
-    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
-    "@aws-cdk/core:target-partitions": [
-      "aws",
-      "aws-cn"
-    ]
-  }
+  "app": "python3 app.py"
 }

--- a/config.py
+++ b/config.py
@@ -49,7 +49,7 @@ class Config(pydantic.BaseSettings):
 
     # Since MCP doesn't allow creating identity pools, setting this as optional
     cognito_groups: Optional[bool] = pydantic.Field(
-        True,
+        False,
         description="whether to create cognito groups with bucket access permissions",
     )
 

--- a/config.py
+++ b/config.py
@@ -32,6 +32,11 @@ class Config(pydantic.BaseSettings):
         description="ARN of role to be assumed by authenticated users in data managers group.",
     )
 
+    data_managers_group: bool = pydantic.Field(
+        False,
+        description="When true create data managers group (mcp-deploy refactor now requires additional control setting to enable creating this group).",
+    )
+
     oidc_provider_url: Optional[str] = pydantic.Field(
         None,
         description="URL of OIDC provider to use for CI workers.",

--- a/config.py
+++ b/config.py
@@ -62,5 +62,10 @@ class Config(pydantic.BaseSettings):
         "", description="The user pool id to use for user management"
     )
 
+    bootstrap_qualifier: Optional[str] = pydantic.Field(
+        None,
+        description="Custom bootstrap qualifier override if not using a default installation of AWS CDK Toolkit to synthesize app.",
+    )
+
 
 app_settings = Config(_env_file=os.environ.get("ENV_FILE", ".env"))

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -376,7 +376,7 @@ class AuthStack(Stack):
         CfnOutput(
             self, 
             "cognito-app-secret", 
-            export_name="cognito_app_secret",
+            export_name="cognito-app-secret",
             value=cognito_app_secret.secret_name
         )
 

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -324,14 +324,24 @@ class AuthStack(Stack):
             user_pool_client_name=name or service_id,
             # disable_o_auth=True,
         )
-
-        self._create_secret(
+        sdk_client_secret = self._get_client_secret(client)
+        cognito_sdk_secret = self._create_secret(
             service_id,
             {
                 "flow": "user_password",
                 "cognito_domain": self.domain.base_url(),
                 "client_id": client.user_pool_client_id,
+                "veda_client_id": client.user_pool_client_id,
+                "veda_client_secret": sdk_client_secret,
+                "veda_userpool_id": self.userpool.user_pool_id,
             },
+        )
+        stack_name = Stack.of(self).stack_name
+        CfnOutput(
+            self, 
+            "cognito-sdk-secret", 
+            export_name=f"{stack_name}-cognito-app-secret",
+            value=cognito_sdk_secret.secret_name
         )
 
         return client

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -356,17 +356,18 @@ class AuthStack(Stack):
             user_pool_client_name=f"{service_id} Service Access",
             disable_o_auth=False,
         )
-
+        # temp: we are going provide client id, secret, and user pool id values twice in the secret (once with veda_ prefix)
+        service_client_secret = self._get_client_secret(client)
         self._create_secret(
             service_id,
             {
                 "flow": "client_credentials",
                 "cognito_domain": self.domain.base_url(),
                 "client_id": client.user_pool_client_id,
-                "client_secret": self._get_client_secret(client),
+                "client_secret": service_client_secret,
                 "userpool_id": self.userpool.user_pool_id,
                 "veda_client_id": client.user_pool_client_id,
-                "veda_client_secret": self._get_client_secret(client),
+                "veda_client_secret": service_client_secret,
                 "veda_userpool_id": self.userpool.user_pool_id,
                 "scope": " ".join(scope.scope_name for scope in scopes),
             },

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -60,22 +60,23 @@ class AuthStack(Stack):
                     "cognito-identity-pool-auth-provider",
                     name="Identity Pool Authentication Provider",
                 )
-                self.identitypool = self._create_identity_pool(
-                    userpool=self.userpool,
-                    auth_provider_client=auth_provider_client,
-                )
-            CfnOutput(
-                self,
-                "identitypool_id",
-                export_name=f"{stack_name}-identitypool-id",
-                value=self.identitypool.identity_pool_id,
-            )
-            CfnOutput(
-                self,
-                "identitypool_arn",
-                export_name=f"{stack_name}-identitypool-arn",
-                value=self.identitypool.identity_pool_arn,
-            )
+                if app_settings.data_managers_role_arn:
+                    self.identitypool = self._create_identity_pool(
+                        userpool=self.userpool,
+                        auth_provider_client=auth_provider_client,
+                    )
+                    CfnOutput(
+                        self,
+                        "identitypool_id",
+                        export_name=f"{stack_name}-identitypool-id",
+                        value=self.identitypool.identity_pool_id,
+                    )
+                    CfnOutput(
+                        self,
+                        "identitypool_arn",
+                        export_name=f"{stack_name}-identitypool-arn",
+                        value=self.identitypool.identity_pool_arn,
+                    )
             # CfnOutput(
             #     self,
             #     "identitypool_client_id",

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -365,6 +365,9 @@ class AuthStack(Stack):
                 "client_id": client.user_pool_client_id,
                 "client_secret": self._get_client_secret(client),
                 "userpool_id": self.userpool.user_pool_id,
+                "veda_client_id": client.user_pool_client_id,
+                "veda_client_secret": self._get_client_secret(client),
+                "veda_userpool_id": self.userpool.user_pool_id,
                 "scope": " ".join(scope.scope_name for scope in scopes),
             },
         )

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -358,7 +358,7 @@ class AuthStack(Stack):
         )
         # temp: we are going provide client id, secret, and user pool id values twice in the secret (once with veda_ prefix)
         service_client_secret = self._get_client_secret(client)
-        self._create_secret(
+        cognito_app_secret = self._create_secret(
             service_id,
             {
                 "flow": "client_credentials",
@@ -371,6 +371,13 @@ class AuthStack(Stack):
                 "veda_userpool_id": self.userpool.user_pool_id,
                 "scope": " ".join(scope.scope_name for scope in scopes),
             },
+        )
+
+        CfnOutput(
+            self, 
+            "cognito-app-secret", 
+            export_name="cognito_app_secret",
+            value=cognito_app_secret.secret_name
         )
 
         return client

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -324,7 +324,6 @@ class AuthStack(Stack):
             user_pool_client_name=name or service_id,
             # disable_o_auth=True,
         )
-        sdk_client_secret = self._get_client_secret(client)
         cognito_sdk_secret = self._create_secret(
             service_id,
             {
@@ -332,7 +331,6 @@ class AuthStack(Stack):
                 "cognito_domain": self.domain.base_url(),
                 "client_id": client.user_pool_client_id,
                 "veda_client_id": client.user_pool_client_id,
-                "veda_client_secret": sdk_client_secret,
                 "veda_userpool_id": self.userpool.user_pool_id,
             },
         )

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -340,7 +340,7 @@ class AuthStack(Stack):
         CfnOutput(
             self, 
             "cognito-sdk-secret", 
-            export_name=f"{stack_name}-cognito-app-secret",
+            export_name=f"{stack_name}-cognito-sdk-secret",
             value=cognito_sdk_secret.secret_name
         )
 

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -372,11 +372,11 @@ class AuthStack(Stack):
                 "scope": " ".join(scope.scope_name for scope in scopes),
             },
         )
-
+        stack_name = Stack.of(self).stack_name
         CfnOutput(
             self, 
             "cognito-app-secret", 
-            export_name="cognito-app-secret",
+            export_name=f"{stack_name}-cognito-app-secret",
             value=cognito_app_secret.secret_name
         )
 

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -364,6 +364,7 @@ class AuthStack(Stack):
                 "cognito_domain": self.domain.base_url(),
                 "client_id": client.user_pool_client_id,
                 "client_secret": self._get_client_secret(client),
+                "userpool_id": self.userpool.user_pool_id,
                 "scope": " ".join(scope.scope_name for scope in scopes),
             },
         )

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -48,7 +48,7 @@ class AuthStack(Stack):
 
         stack_name = Stack.of(self).stack_name
 
-        if app_settings.cognito_groups:
+        if app_settings.cognito_groups or app_settings.data_managers_group:
             self._group_precedence = 0
 
             if app_settings.identity_pool_arn:

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -2,7 +2,7 @@ import json
 from enum import Enum
 from typing import Any, Dict, Optional, Sequence
 
-from aws_cdk import CfnOutput, RemovalPolicy, SecretValue, Stack
+from aws_cdk import Aspects, CfnOutput, RemovalPolicy, SecretValue, Stack
 from aws_cdk import aws_cognito as cognito
 from aws_cdk import aws_cognito_identitypool_alpha as cognito_id_pool
 from aws_cdk import aws_iam as iam
@@ -10,7 +10,6 @@ from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_secretsmanager as secretsmanager
 from aws_cdk import custom_resources as cr
 from constructs import Construct
-from aws_cdk import Aspects
 
 from config import Config
 
@@ -336,10 +335,10 @@ class AuthStack(Stack):
         )
         stack_name = Stack.of(self).stack_name
         CfnOutput(
-            self, 
-            "cognito-sdk-secret", 
+            self,
+            f"cognito-sdk-{service_id}-secret",
             export_name=f"{stack_name}-cognito-sdk-secret",
-            value=cognito_sdk_secret.secret_name
+            value=cognito_sdk_secret.secret_name,
         )
 
         return client
@@ -382,10 +381,10 @@ class AuthStack(Stack):
         )
         stack_name = Stack.of(self).stack_name
         CfnOutput(
-            self, 
-            "cognito-app-secret", 
+            self,
+            f"cognito-app-{service_id}-secret",
             export_name=f"{stack_name}-cognito-app-secret",
-            value=cognito_app_secret.secret_name
+            value=cognito_app_secret.secret_name,
         )
 
         return client

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ boto3==1.24.15
 boto3-stubs[cognito-idp,cognito-identity]
 flake8==4.0.1
 click==8.1.3
-requests==2.28.0
+requests==2.31.0
 pre-commit==3.0.4
 pydantic[dotenv]

--- a/scripts/get-env.sh
+++ b/scripts/get-env.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Use this script to load environment variables for a deployment from AWS Secrets
+
+for s in $(aws secretsmanager get-secret-value --secret-id $1 --query SecretString --output text | jq -r "to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]" ); do
+    echo "$s" >> $GITHUB_ENV
+done


### PR DESCRIPTION
## Changes
- adds externally triggered veda deploy action
- adds new variables to workflows secret for downstream ingest system to pick up
- restores method to generate a data managers user group onlyl when explicitly configured
- addresses requests version security bug
- temporarily suppresses cicd template that is not yet configured for operations and adds a minimal cdk diff check when prs are opened
- includes additional veda_ prefixed client variables to support systems expecting the prefix (current client_id etc still stored)