### PR TITLE
fix(ci): fixes for newer aws-cdk version and automated branch deployments

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - main
       - dev
-      - fix/ci-for-dev
 
 jobs:
   define-environment:
@@ -23,9 +22,6 @@ jobs:
             echo "env_name=staging" >> $GITHUB_OUTPUT
             echo "secret_name=veda-auth-uah-env" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref }}" = "refs/heads/dev" ]; then
-            echo "env_name=development" >> $GITHUB_OUTPUT
-            echo "secret_name=veda-auth-dev-env" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref }}" = "refs/heads/fix/ci-for-dev" ]; then
             echo "env_name=development" >> $GITHUB_OUTPUT
             echo "secret_name=veda-auth-dev-env" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - dev
+      - fix/ci-for-dev
 
 jobs:
   define-environment:
@@ -22,6 +23,9 @@ jobs:
             echo "env_name=staging" >> $GITHUB_OUTPUT
             echo "secret_name=veda-auth-uah-env" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref }}" = "refs/heads/dev" ]; then
+            echo "env_name=development" >> $GITHUB_OUTPUT
+            echo "secret_name=veda-auth-dev-env" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref }}" = "refs/heads/fix/ci-for-dev" ]; then
             echo "env_name=development" >> $GITHUB_OUTPUT
             echo "secret_name=veda-auth-dev-env" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,7 +22,7 @@ jobs:
             echo "env_name=staging" >> $GITHUB_OUTPUT
             echo "secret_name=veda-auth-uah-env" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref }}" = "refs/heads/dev" ]; then
-            echo "env_name=development" >> $GITHUB_OUTPUT
+            echo "env_name=dev" >> $GITHUB_OUTPUT
             echo "secret_name=veda-auth-dev-env" >> $GITHUB_OUTPUT
           fi
       - name: Print the environment
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 17
+          node-version: 20
 
       - name: Configure awscli
         uses: aws-actions/configure-aws-credentials@v3

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - main
       - dev
-      - production
 
 jobs:
   define-environment:
@@ -21,18 +20,17 @@ jobs:
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "env_name=staging" >> $GITHUB_OUTPUT
-            echo "secret_name=veda-auth-staging" >> $GITHUB_OUTPUT
+            echo "secret_name=veda-auth-uah-env" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref }}" = "refs/heads/dev" ]; then
             echo "env_name=development" >> $GITHUB_OUTPUT
-            echo "secret_name=veda-auth-dev" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref }}" = "refs/heads/production" ]; then
-            echo "env_name=production" >> $GITHUB_OUTPUT
+            echo "secret_name=veda-auth-dev-env" >> $GITHUB_OUTPUT
           fi
       - name: Print the environment
         run: echo "The environment is ${{ steps.define_environment.outputs.env_name }}"
 
     outputs:
       env_name: ${{ steps.define_environment.outputs.env_name }}
+      secret_name: ${{ steps.define_environment.outputs.secret_name }}
 
   deploy:
     name: Deploy to ${{ needs.define-environment.outputs.env_name }} 🚀
@@ -43,20 +41,46 @@ jobs:
     concurrency: ${{ needs.define-environment.outputs.env_name }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          lfs: "true"
-          submodules: "recursive"
-        
+          python-version: '3.9'
+      
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 17
+
       - name: Configure awscli
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
-          role-session-name: "veda-auth-github-${{ needs.define-environment.outputs.env_name }}-deployment"
-          aws-region: "us-west-2"
-
-      - name: Run deployment
-        uses: "./.github/actions/cdk-deploy"
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      
+      - uses: actions/cache@v3
         with:
-          env_aws_secret_name: ${{ secrets.ENV_AWS_SECRET_NAME }}
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install CDK
+        run: npm install -g aws-cdk@2
+        
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key:  ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
+          
+      - name: Install python dependencies
+        run: |
+          pip install -r requirements.txt
+          
+      - name: Get environment configuration for target branch
+        run: |
+          ./scripts/get-env.sh ${{ needs.define-environment.outputs.secret_name }}
+          
+      - name: Deploy
+        run: |
+          echo $STAGE
+          cdk deploy --require-approval never --outputs-file ${HOME}/cdk-outputs.json

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Pre deployment CDK diff
         run: |
           echo $STAGE
-          cdk diff --outputs-file ${HOME}/cdk-outputs.json
+          cdk diff -v --outputs-file ${HOME}/cdk-outputs.json

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,9 +19,10 @@ jobs:
           fi
       - name: Print the environment
         run: echo "The environment is ${{ steps.define_environment.outputs.env_name }}"
-      outputs:
-        env_name: ${{ steps.define_environment.outputs.env_name }}
-        secret_name: ${{ steps.define_environment.outputs.secret_name }}
+        
+    outputs:
+      env_name: ${{ steps.define_environment.outputs.env_name }}
+      secret_name: ${{ steps.define_environment.outputs.secret_name }}
     
 
   predeploy:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,9 @@
 name: Pull Request - Preview CDK Diff
 
+permissions:
+  id-token: write
+  contents: read
+
 on: [pull_request]
 
 jobs:
@@ -10,16 +14,16 @@ jobs:
       - name: Set the environment
         id: define_environment
         run: |
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "${{ github.base_ref }}" == "main" ]; then
             echo "env_name=staging" >> $GITHUB_OUTPUT
             echo "secret_name=veda-auth-uah-env" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref }}" = "refs/heads/dev" ]; then
-            echo "env_name=development" >> $GITHUB_OUTPUT
+          elif [ "${{ github.base_ref }}" == "dev" ]; then
+            echo "env_name=dev" >> $GITHUB_OUTPUT
             echo "secret_name=veda-auth-dev-env" >> $GITHUB_OUTPUT
           fi
       - name: Print the environment
         run: echo "The environment is ${{ steps.define_environment.outputs.env_name }}"
-        
+
     outputs:
       env_name: ${{ steps.define_environment.outputs.env_name }}
       secret_name: ${{ steps.define_environment.outputs.secret_name }}
@@ -39,7 +43,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 17
+          node-version: 20
 
       - name: Configure awscli
         uses: aws-actions/configure-aws-credentials@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Pre deployment CDK diff
         run: |
           echo $STAGE
-          cdk diff -v --outputs-file ${HOME}/cdk-outputs.json
+          cdk diff --outputs-file ${HOME}/cdk-outputs.json

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,7 +43,12 @@ jobs:
 
       - name: Get environment configuration for target branch
         run: |
-          ./scripts/get-env.sh "veda-auth-uah-env"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            ./scripts/get-env.sh "veda-auth-uah-env"
+          elif [ "${{ github.ref }}" = "refs/heads/dev" ]; then
+            ./scripts/get-env.sh "veda-auth-dev-env"
+          fi
+
       - name: Pre deployment CDK diff
         run: |
           echo $STAGE

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,30 @@ name: Pull Request - Preview CDK Diff
 on: [pull_request]
 
 jobs:
+  define-environment:
+    name: Set ✨ environment ✨ based on the branch 🌳
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set the environment
+        id: define_environment
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "env_name=staging" >> $GITHUB_OUTPUT
+            echo "secret_name=veda-auth-uah-env" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref }}" = "refs/heads/dev" ]; then
+            echo "env_name=development" >> $GITHUB_OUTPUT
+            echo "secret_name=veda-auth-dev-env" >> $GITHUB_OUTPUT
+          fi
+      - name: Print the environment
+        run: echo "The environment is ${{ steps.define_environment.outputs.env_name }}"
+      outputs:
+        env_name: ${{ steps.define_environment.outputs.env_name }}
+        secret_name: ${{ steps.define_environment.outputs.secret_name }}
+    
+
   predeploy:
+    name: Pre-deploy cdk diff for ${{ needs.define-environment.outputs.env_name }} 🚀
+    needs: [define-environment]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -43,11 +66,7 @@ jobs:
 
       - name: Get environment configuration for target branch
         run: |
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            ./scripts/get-env.sh "veda-auth-uah-env"
-          elif [ "${{ github.ref }}" = "refs/heads/dev" ]; then
-            ./scripts/get-env.sh "veda-auth-dev-env"
-          fi
+          ./scripts/get-env.sh ${{ needs.define-environment.outputs.secret_name }}
 
       - name: Pre deployment CDK diff
         run: |

--- a/cdk.json
+++ b/cdk.json
@@ -1,3 +1,4 @@
 {
-  "app": "python3 app.py"
+  "app": "python3 app.py",
+  "@aws-cdk/customresources:installLatestAwsSdkDefault": false
 }

--- a/cdk.json
+++ b/cdk.json
@@ -1,4 +1,6 @@
 {
   "app": "python3 app.py",
-  "@aws-cdk/customresources:installLatestAwsSdkDefault": false
+  "context": {
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false
+  }
 }

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -354,6 +354,26 @@ class AuthStack(Stack):
             disable_o_auth=False,
         )
 
+        self._create_secret(
+            service_id,
+            {
+                "flow": "client_credentials",
+                "cognito_domain": self.domain.base_url(),
+                "client_id": client.user_pool_client_id,
+                "client_secret": self._get_client_secret(client),
+                "userpool_id": self.userpool.user_pool_id,
+                "scope": " ".join(scope.scope_name for scope in scopes),
+            },
+        )
+
+        stack_name = Stack.of(self).stack_name
+        CfnOutput(
+            self,
+            f"cognito-app-{service_id}-secret",
+            export_name=f"{stack_name}-cognito-app-secret",
+            value=f"{stack_name}/{service_id}",
+        )
+
         return client
 
     @property

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -326,8 +326,7 @@ class AuthStack(Stack):
                 "flow": "user_password",
                 "cognito_domain": self.domain.base_url(),
                 "client_id": client.user_pool_client_id,
-                "veda_client_id": client.user_pool_client_id,
-                "veda_userpool_id": self.userpool.user_pool_id,
+                "userpool_id": self.userpool.user_pool_id,
             },
         )
         stack_name = Stack.of(self).stack_name

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -330,13 +330,6 @@ class AuthStack(Stack):
                 "veda_userpool_id": self.userpool.user_pool_id,
             },
         )
-        stack_name = Stack.of(self).stack_name
-        CfnOutput(
-            self,
-            f"{service_id}-secret",
-            export_name=f"{service_id}-secret",
-            value=cognito_sdk_secret.secret_name,
-        )
 
         return client
 

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -353,29 +353,6 @@ class AuthStack(Stack):
             user_pool_client_name=f"{service_id} Service Access",
             disable_o_auth=False,
         )
-        # temp: we are going provide client id, secret, and user pool id values twice in the secret (once with veda_ prefix)
-        service_client_secret = self._get_client_secret(client)
-        cognito_app_secret = self._create_secret(
-            service_id,
-            {
-                "flow": "client_credentials",
-                "cognito_domain": self.domain.base_url(),
-                "client_id": client.user_pool_client_id,
-                "client_secret": service_client_secret,
-                "userpool_id": self.userpool.user_pool_id,
-                "veda_client_id": client.user_pool_client_id,
-                "veda_client_secret": service_client_secret,
-                "veda_userpool_id": self.userpool.user_pool_id,
-                "scope": " ".join(scope.scope_name for scope in scopes),
-            },
-        )
-        stack_name = Stack.of(self).stack_name
-        CfnOutput(
-            self,
-            f"cognito-app-{service_id}-secret",
-            export_name=f"{stack_name}-cognito-app-secret",
-            value=cognito_app_secret.secret_name,
-        )
 
         return client
 

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -59,7 +59,7 @@ class AuthStack(Stack):
                 )
             else:
                 auth_provider_client = self.add_programmatic_client(
-                    "cognito-identity-pool-auth-provider",
+                    f"{stack_name}-identity-provider",
                     name="Identity Pool Authentication Provider",
                 )
                 if app_settings.data_managers_role_arn:
@@ -333,8 +333,8 @@ class AuthStack(Stack):
         stack_name = Stack.of(self).stack_name
         CfnOutput(
             self,
-            f"cognito-sdk-{service_id}-secret",
-            export_name=f"{stack_name}-cognito-sdk-secret",
+            f"{service_id}-secret",
+            export_name=f"{service_id}-secret",
             value=cognito_sdk_secret.secret_name,
         )
 

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -320,7 +320,7 @@ class AuthStack(Stack):
             user_pool_client_name=name or service_id,
             # disable_o_auth=True,
         )
-        cognito_sdk_secret = self._create_secret(
+        self._create_secret(
             service_id,
             {
                 "flow": "user_password",
@@ -329,6 +329,13 @@ class AuthStack(Stack):
                 "veda_client_id": client.user_pool_client_id,
                 "veda_userpool_id": self.userpool.user_pool_id,
             },
+        )
+        stack_name = Stack.of(self).stack_name
+        CfnOutput(
+            self,
+            f"cognito-sdk-{service_id}-secret",
+            export_name=f"{stack_name}-cognito-sdk-secret",
+            value=f"{stack_name}/{service_id}",
         )
 
         return client


### PR DESCRIPTION
# What
Minimum viable branch and push cicd updates and various fixes 
- updated aws-cdk version requires additional cdk context `"@aws-cdk/customresources:installLatestAwsSdkDefault": false`
- cicd.yml simplified (for now) to automatically deploy on dev and main branches. In the future we may want to implement the pattern of calling the cdk-actions/workflow that is used for production for the lower environments as well but today the lower environment aws setup lacks the appropriate deployment role
- stop creating an additional copy of the workflows client secret with appended duplicate values with veda_ in keys (workflows client no longer used this way)

# How tested
Temporarily executed cdk deploy to dev stack on push to this fix branch.