### PR TITLE
feat(ci)!: modifications for externally triggered deployments and upgrades

### DIFF
--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -16,9 +16,9 @@ runs:
   using: "composite"
   steps:
     - name: Install node and related deps
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: 17.3.0
+        node-version: 20
 
     - uses: actions/cache@v3
       with:
@@ -30,7 +30,7 @@ runs:
       run: npm install -g aws-cdk@2
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
         cache: "pip"
@@ -49,7 +49,13 @@ runs:
       working-directory: ${{ inputs.dir }}
       env:
         AWS_DEFAULT_REGION: us-west-2
-      run: ./scripts/get-env.sh ${{ inputs.env_aws_secret_name }}
+      run: |
+        if [[ -z "${{ inputs.script_path }}" ]]; then
+        ./scripts/sync-env.sh ${{ inputs.env_aws_secret_name }}
+        else
+        python ${{ inputs.script_path }} --secret-id ${{ inputs.env_aws_secret_name }}
+        fi
+
 
     - name: Deploy
       id: deploy_auth_stack

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - main
       - dev
-      - production
 
 jobs:
   define-environment:
@@ -21,18 +20,17 @@ jobs:
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "env_name=staging" >> $GITHUB_OUTPUT
-            echo "secret_name=veda-auth-staging" >> $GITHUB_OUTPUT
+            echo "secret_name=veda-auth-uah-env" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref }}" = "refs/heads/dev" ]; then
-            echo "env_name=development" >> $GITHUB_OUTPUT
-            echo "secret_name=veda-auth-dev" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref }}" = "refs/heads/production" ]; then
-            echo "env_name=production" >> $GITHUB_OUTPUT
+            echo "env_name=dev" >> $GITHUB_OUTPUT
+            echo "secret_name=veda-auth-dev-env" >> $GITHUB_OUTPUT
           fi
       - name: Print the environment
         run: echo "The environment is ${{ steps.define_environment.outputs.env_name }}"
 
     outputs:
       env_name: ${{ steps.define_environment.outputs.env_name }}
+      secret_name: ${{ steps.define_environment.outputs.secret_name }}
 
   deploy:
     name: Deploy to ${{ needs.define-environment.outputs.env_name }} 🚀
@@ -43,20 +41,46 @@ jobs:
     concurrency: ${{ needs.define-environment.outputs.env_name }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          lfs: "true"
-          submodules: "recursive"
-        
+          python-version: '3.9'
+      
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
       - name: Configure awscli
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
-          role-session-name: "veda-auth-github-${{ needs.define-environment.outputs.env_name }}-deployment"
-          aws-region: "us-west-2"
-
-      - name: Run deployment
-        uses: "./.github/actions/cdk-deploy"
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      
+      - uses: actions/cache@v3
         with:
-          env_aws_secret_name: ${{ secrets.ENV_AWS_SECRET_NAME }}
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install CDK
+        run: npm install -g aws-cdk@2
+        
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key:  ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
+          
+      - name: Install python dependencies
+        run: |
+          pip install -r requirements.txt
+          
+      - name: Get environment configuration for target branch
+        run: |
+          ./scripts/get-env.sh ${{ needs.define-environment.outputs.secret_name }}
+          
+      - name: Deploy
+        run: |
+          echo $STAGE
+          cdk deploy --require-approval never --outputs-file ${HOME}/cdk-outputs.json

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,7 +7,9 @@ permissions:
 on:
   push:
     branches:
-      - make-mcp-ready
+      - main
+      - dev
+      - production
 
 jobs:
   define-environment:
@@ -25,7 +27,6 @@ jobs:
             echo "secret_name=veda-auth-dev" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref }}" = "refs/heads/production" ]; then
             echo "env_name=production" >> $GITHUB_OUTPUT
-            echo "secret_name=veda-auth-production" >> $GITHUB_OUTPUT
           fi
       - name: Print the environment
         run: echo "The environment is ${{ steps.define_environment.outputs.env_name }}"
@@ -51,41 +52,11 @@ jobs:
       - name: Configure awscli
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
+          role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
+          role-session-name: "veda-auth-github-${{ needs.define-environment.outputs.env_name }}-deployment"
+          aws-region: "us-west-2"
 
-      - name: Install node and related deps
-        uses: actions/setup-node@v3
+      - name: Run deployment
+        uses: "./.github/actions/cdk-deploy"
         with:
-          node-version: 17.3.0
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-
-      - name: Install AWS CDK
-        shell: bash
-        run: npm install -g aws-cdk@2
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-          cache: "pip"
-          cache-dependency-path: requirements.txt
-
-      - name: Install python dependencies
-        run: |
-          pip install \
-            -r requirements.txt \
-
-      - name: Get environment configuration from aws secrets
-        run: ./scripts/get-env.sh  ${{ needs.define-environment.outputs.secret_name }}
-
-      - name: Deploy
-        env:
-          AWS_DEFAULT_REGION: us-west-2
-          CDK_DEFAULT_REGION: us-west-2
-        run: cdk deploy --all --require-approval never
+          env_aws_secret_name: ${{ secrets.ENV_AWS_SECRET_NAME }}

--- a/.github/workflows/gitflow-enforcer.yml
+++ b/.github/workflows/gitflow-enforcer.yml
@@ -1,0 +1,19 @@
+name: Gitflow enforcer 🚀
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+      - production
+    types: [ opened, reopened, edited, synchronize ]
+
+jobs:
+  gitflow-enforcer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch
+        if: github.base_ref == 'main' && github.head_ref != 'dev' || github.base_ref == 'production' && github.head_ref != 'main'
+        run: |
+          echo "ERROR: You can only merge to main from dev and to production from main"
+          exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,9 +1,37 @@
 name: Pull Request - Preview CDK Diff
 
+permissions:
+  id-token: write
+  contents: read
+
 on: [pull_request]
 
 jobs:
+  define-environment:
+    name: Set ✨ environment ✨ based on the branch 🌳
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set the environment
+        id: define_environment
+        run: |
+          if [ "${{ github.base_ref }}" == "main" ]; then
+            echo "env_name=staging" >> $GITHUB_OUTPUT
+            echo "secret_name=veda-auth-uah-env" >> $GITHUB_OUTPUT
+          elif [ "${{ github.base_ref }}" == "dev" ]; then
+            echo "env_name=dev" >> $GITHUB_OUTPUT
+            echo "secret_name=veda-auth-dev-env" >> $GITHUB_OUTPUT
+          fi
+      - name: Print the environment
+        run: echo "The environment is ${{ steps.define_environment.outputs.env_name }}"
+
+    outputs:
+      env_name: ${{ steps.define_environment.outputs.env_name }}
+      secret_name: ${{ steps.define_environment.outputs.secret_name }}
+    
+
   predeploy:
+    name: Pre-deploy cdk diff for ${{ needs.define-environment.outputs.env_name }} 🚀
+    needs: [define-environment]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -15,7 +43,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 17
+          node-version: 20
 
       - name: Configure awscli
         uses: aws-actions/configure-aws-credentials@v3
@@ -43,7 +71,8 @@ jobs:
 
       - name: Get environment configuration for target branch
         run: |
-          ./scripts/get-env.sh "veda-auth-uah-env"
+          ./scripts/get-env.sh ${{ needs.define-environment.outputs.secret_name }}
+
       - name: Pre deployment CDK diff
         run: |
           echo $STAGE

--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import subprocess
 
-from aws_cdk import App, Tags, DefaultStackSynthesizer
+from aws_cdk import App, CfnOutput, Tags, DefaultStackSynthesizer
 
 from infra.stack import AuthStack, BucketPermissions
 
@@ -11,7 +11,7 @@ app = App()
 
 stack = AuthStack(
     app, 
-    f"veda-auth-stack-{app_settings.stage}", 
+    f"{app_settings.app_name}-{app_settings.stage}", 
     app_settings,
     synthesizer=DefaultStackSynthesizer(
         qualifier=app_settings.bootstrap_qualifier
@@ -98,7 +98,13 @@ if oidc_thumbprint and oidc_provider_url:
     )
 
 # Programmatic Clients
-stack.add_programmatic_client("veda-sdk")
+client = stack.add_programmatic_client(f"{app_settings.app_name}-{app_settings.stage}-veda-sdk")
+CfnOutput(
+    stack,
+    "client_id",
+    export_name=f"{app_settings.app_name}-{app_settings.stage}-client-id",
+    value=client.user_pool_client_id,
+)
 
 # Frontend Clients
 # stack.add_frontend_client('veda-dashboard')

--- a/cdk.json
+++ b/cdk.json
@@ -1,3 +1,6 @@
 {
-  "app": "python3 app.py"
+  "app": "python3 app.py",
+  "context": {
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false
+  }
 }

--- a/config.py
+++ b/config.py
@@ -7,6 +7,11 @@ import pydantic
 
 
 class Config(pydantic.BaseSettings):
+    # App name and deployment stage
+    app_name: Optional[str] = pydantic.Field(
+        "veda-auth-stack",
+        description="Optional app name used to name stack and resources",
+    )
     stage: str = pydantic.Field(
         description=" ".join(
             [

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -13,7 +13,6 @@ from constructs import Construct
 
 from config import Config
 
-
 class BucketPermissions(str, Enum):
     read_only = "r"
     read_write = "wr"
@@ -44,9 +43,13 @@ class AuthStack(Stack):
         else:
             self.userpool = self._create_userpool()
         self.domain = self._add_domain(self.userpool)
-
         stack_name = Stack.of(self).stack_name
-
+        CfnOutput(
+            self,
+            "userpool_id",
+            export_name=f"{stack_name}-userpool-id",
+            value=self.userpool.user_pool_id,
+        )
         if app_settings.cognito_groups or app_settings.data_managers_group:
             self._group_precedence = 0
 
@@ -224,12 +227,6 @@ class AuthStack(Stack):
             secret_string_value=SecretValue.unsafe_plain_text(json.dumps(secret_dict)),
         )
 
-        CfnOutput(
-            self,
-            f"{service_id}-secret-output",
-            export_name=f"{stack_name}-{service_id}-secret",
-            value=secret.secret_name,
-        )
         CfnOutput(
             self,
             f"{service_id}-secret-arn-output",

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -59,7 +59,7 @@ class AuthStack(Stack):
                 )
             else:
                 auth_provider_client = self.add_programmatic_client(
-                    "cognito-identity-pool-auth-provider",
+                    f"{stack_name}-identity-provider",
                     name="Identity Pool Authentication Provider",
                 )
                 if app_settings.data_managers_role_arn:
@@ -320,14 +320,13 @@ class AuthStack(Stack):
             user_pool_client_name=name or service_id,
             # disable_o_auth=True,
         )
-        cognito_sdk_secret = self._create_secret(
+        self._create_secret(
             service_id,
             {
                 "flow": "user_password",
                 "cognito_domain": self.domain.base_url(),
                 "client_id": client.user_pool_client_id,
-                "veda_client_id": client.user_pool_client_id,
-                "veda_userpool_id": self.userpool.user_pool_id,
+                "userpool_id": self.userpool.user_pool_id,
             },
         )
         stack_name = Stack.of(self).stack_name
@@ -335,7 +334,7 @@ class AuthStack(Stack):
             self,
             f"cognito-sdk-{service_id}-secret",
             export_name=f"{stack_name}-cognito-sdk-secret",
-            value=cognito_sdk_secret.secret_name,
+            value=f"{stack_name}/{service_id}",
         )
 
         return client
@@ -360,28 +359,25 @@ class AuthStack(Stack):
             user_pool_client_name=f"{service_id} Service Access",
             disable_o_auth=False,
         )
-        # temp: we are going provide client id, secret, and user pool id values twice in the secret (once with veda_ prefix)
-        service_client_secret = self._get_client_secret(client)
-        cognito_app_secret = self._create_secret(
+
+        self._create_secret(
             service_id,
             {
                 "flow": "client_credentials",
                 "cognito_domain": self.domain.base_url(),
                 "client_id": client.user_pool_client_id,
-                "client_secret": service_client_secret,
+                "client_secret": self._get_client_secret(client),
                 "userpool_id": self.userpool.user_pool_id,
-                "veda_client_id": client.user_pool_client_id,
-                "veda_client_secret": service_client_secret,
-                "veda_userpool_id": self.userpool.user_pool_id,
                 "scope": " ".join(scope.scope_name for scope in scopes),
             },
         )
+
         stack_name = Stack.of(self).stack_name
         CfnOutput(
             self,
             f"cognito-app-{service_id}-secret",
             export_name=f"{stack_name}-cognito-app-secret",
-            value=cognito_app_secret.secret_name,
+            value=f"{stack_name}/{service_id}",
         )
 
         return client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-aws-cdk-lib==2.35.0
-aws_cdk.aws_cognito_identitypool_alpha==2.35.0a0
+aws-cdk-lib==2.112.0
+aws_cdk.aws_cognito_identitypool_alpha>=2.112.0a0
 constructs>=10.0.0,<11.0.0
 pydantic==1.9.1
 black==22.3.0


### PR DESCRIPTION

## Changes
### CICD
- Add composite action to be used by `veda-deploy`
- Update cicd to use the composite action
- Add gitflow enforcer
- Add CfnOutput to pass env vars between stacks in `veda-deploy` 
- Cicd.yml simplified (for now) to automatically deploy on dev and main branches. In the future we may want to implement the pattern of calling the cdk-actions/workflow that is used for production for the lower environments as well but today the lower environment aws setup lacks the appropriate deployment role

### Upgrades
- Upgrade to latest aws-cdk version https://github.com/aws/aws-cdk/releases?q=node&expanded=true to use latest node runtime version for `AwsCustomResource` https://github.com/NASA-IMPACT/veda-auth/blob/main/infra/stack.py#L176-L199
- Updated aws-cdk version requires additional cdk context `"@aws-cdk/customresources:installLatestAwsSdkDefault": false`

## Breaking changes
- Stop creating an additional duplicate values with veda_ in keys client aws secrets manager (no longer required for downstream deployment)