### PR TITLE
fix: unique export names for cfn outputs

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,7 +80,7 @@ stac_registry_scopes = stack.add_resource_server(
 # In this case, we want this client to be able to only register new STAC ingestions in
 # the STAC ingestion registry service.
 stack.add_service_client(
-    "veda-workflows",
+    "workflows-client",
     scopes=[
         stac_registry_scopes["stac:register"],
     ],
@@ -98,7 +98,7 @@ if oidc_thumbprint and oidc_provider_url:
     )
 
 # Programmatic Clients
-client = stack.add_programmatic_client(f"{app_settings.app_name}-{app_settings.stage}-veda-sdk")
+client = stack.add_programmatic_client("programmatic-client")
 CfnOutput(
     stack,
     "client_id",

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -59,7 +59,7 @@ class AuthStack(Stack):
                 )
             else:
                 auth_provider_client = self.add_programmatic_client(
-                    f"{stack_name}-identity-provider",
+                    "identity-provider",
                     name="Identity Pool Authentication Provider",
                 )
                 if app_settings.data_managers_role_arn:
@@ -332,8 +332,8 @@ class AuthStack(Stack):
         stack_name = Stack.of(self).stack_name
         CfnOutput(
             self,
-            f"cognito-sdk-{service_id}-secret",
-            export_name=f"{stack_name}-{service_id}-cognito-sdk-secret",
+            f"{service_id}-secret-id",
+            export_name=f"{stack_name}-{service_id}-secret-id",
             value=f"{stack_name}/{service_id}",
         )
 
@@ -375,8 +375,8 @@ class AuthStack(Stack):
         stack_name = Stack.of(self).stack_name
         CfnOutput(
             self,
-            f"cognito-app-{service_id}-secret",
-            export_name=f"{stack_name}-{service_id}-cognito-app-secret",
+            f"{service_id}-secret-id",
+            export_name=f"{stack_name}-{service_id}-secret-id",
             value=f"{stack_name}/{service_id}",
         )
 

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -333,7 +333,7 @@ class AuthStack(Stack):
         CfnOutput(
             self,
             f"cognito-sdk-{service_id}-secret",
-            export_name=f"{stack_name}-cognito-sdk-secret",
+            export_name=f"{stack_name}-{service_id}-cognito-sdk-secret",
             value=f"{stack_name}/{service_id}",
         )
 
@@ -376,7 +376,7 @@ class AuthStack(Stack):
         CfnOutput(
             self,
             f"cognito-app-{service_id}-secret",
-            export_name=f"{stack_name}-cognito-app-secret",
+            export_name=f"{stack_name}-{service_id}-cognito-app-secret",
             value=f"{stack_name}/{service_id}",
         )
 

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -320,6 +320,8 @@ class AuthStack(Stack):
             user_pool_client_name=name or service_id,
             # disable_o_auth=True,
         )
+
+        region = Stack.of(self).region
         self._create_secret(
             service_id,
             {
@@ -327,6 +329,7 @@ class AuthStack(Stack):
                 "cognito_domain": self.domain.base_url(),
                 "client_id": client.user_pool_client_id,
                 "userpool_id": self.userpool.user_pool_id,
+                "aws_region": region,
             },
         )
         stack_name = Stack.of(self).stack_name
@@ -360,6 +363,7 @@ class AuthStack(Stack):
             disable_o_auth=False,
         )
 
+        region = Stack.of(self).region
         self._create_secret(
             service_id,
             {
@@ -369,6 +373,7 @@ class AuthStack(Stack):
                 "client_secret": self._get_client_secret(client),
                 "userpool_id": self.userpool.user_pool_id,
                 "scope": " ".join(scope.scope_name for scope in scopes),
+                "aws_region": region,
             },
         )
 


### PR DESCRIPTION
## What
- Fixes `The Outputs section contains duplicate Export names` by making client secret id export names unique (and more specific). New export names are:
  - `{stack_name}-workflows-client-secret-id` for the service client secret used by airflow
  - `{stack_name}-programmatic-client-secret-id` for the use password token generating client used for endpoints that grant tokens (ingest-api, maybe workflows-api in future)
  - `{stack_name}-identity-provider-secret-id` for the optional data managers group (not used in higher environments)
- Adds `aws_region` to each stored client secret

## How tested
I reviewed the pre commit cdk diff for the dev stack and manually ran the cdk diff against the staging auth stack locally.