### PR TITLE
fix(ci): use dedicated staging environment config in ci

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "env_name=staging" >> $GITHUB_OUTPUT
-            echo "secret_name=veda-auth-uah-env" >> $GITHUB_OUTPUT
+            echo "secret_name=veda-auth-staging-env" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref }}" = "refs/heads/dev" ]; then
             echo "env_name=dev" >> $GITHUB_OUTPUT
             echo "secret_name=veda-auth-dev-env" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           if [ "${{ github.base_ref }}" == "main" ]; then
             echo "env_name=staging" >> $GITHUB_OUTPUT
-            echo "secret_name=veda-auth-uah-env" >> $GITHUB_OUTPUT
+            echo "secret_name=veda-auth-staging-env" >> $GITHUB_OUTPUT
           elif [ "${{ github.base_ref }}" == "dev" ]; then
             echo "env_name=dev" >> $GITHUB_OUTPUT
             echo "secret_name=veda-auth-dev-env" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What
Github automated pr and push workflows updated to use a new aws secrets manager config in `veda-auth-staging-env` to avoid causing changes to legacy uah auth stack that is used by unmaintained but still supported services like veda-stac-ingestor. The result will be that we have two automatically deployed auth stacks (dev and staging) and will no longer automatically update the existing veda-auth-stack-uah.

## Why
Caution. The most recent update to veda-auth-stack-dev which had not been redeployed for over a year caused a change to the programmatic client id. It is not clear that these changes would impact the uah stack but, just in case, let's add a new more logically named staging auth stack for our staging veda system.