### PR TITLE
fix: temporary hack to create an exact export name

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,7 +98,9 @@ if oidc_thumbprint and oidc_provider_url:
     )
 
 # Programmatic Clients
-client = stack.add_programmatic_client("programmatic-client")
+# Note add_cognito_app_secret_export forces an export named <stack-name>-cognito-app-secret 
+# but defaults to False to avoid duplicate export names for mulitple clients
+client = stack.add_programmatic_client("programmatic-client", add_congito_app_secret_export=True)
 CfnOutput(
     stack,
     "client_id",

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -347,7 +347,7 @@ class AuthStack(Stack):
             CfnOutput(
             self,
             f"{service_id}-duplicate-export-cognito-app-secret",
-            export_name=f"{stack_name}-cognito_app_secret",
+            export_name=f"{stack_name}-cognito-app-secret",
             value=f"{stack_name}/{service_id}",
         )
 

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -312,6 +312,7 @@ class AuthStack(Stack):
         self,
         service_id: str,
         name: Optional[str] = None,
+        add_congito_app_secret_export: Optional[bool] = False,
     ) -> cognito.UserPoolClient:
         client = self.userpool.add_client(
             service_id,
@@ -337,6 +338,16 @@ class AuthStack(Stack):
             self,
             f"{service_id}-secret-id",
             export_name=f"{stack_name}-{service_id}-secret-id",
+            value=f"{stack_name}/{service_id}",
+        )
+
+        # Temporarily support a downstream application looking for this exact export name, 
+        # this will fail if multiple clients are configured with this flag set to true
+        if add_congito_app_secret_export:
+            CfnOutput(
+            self,
+            f"{service_id}-duplicate-export-cognito-app-secret",
+            export_name=f"{stack_name}-cognito_app_secret",
             value=f"{stack_name}/{service_id}",
         )
 


### PR DESCRIPTION
Temporary hack to create an exact export name and reduce the likelihood of a duplicate export error by using a flag that defaults false. 

A downstream application needs a cf export name `<stack-name>-cognito-app-secret`, to cause this exact pattern to be used only once, only enable `add_congito_app_secret_export` for one programmatic client.