### PR TITLE
fix: change export name of cognito domain for ci

### DIFF
--- a/infra/stack.py
+++ b/infra/stack.py
@@ -174,6 +174,13 @@ class AuthStack(Stack):
             value=domain.base_url(),
         )
 
+        CfnOutput(
+            self,
+            "cognito-domain",
+            export_name=f"{stack_name}-cognito_domain",
+            value=domain.base_url(),
+        )
+
         return domain
 
     def _get_client_secret(


### PR DESCRIPTION
## what
Add an additional cfn export that matches the variable name expected by workflows deployment
