### PR TITLE
fix: change export name of cognito domain for ci 

### DIFF
--- a/infra/stack.py
+++ b/infra/stack.py
@@ -174,6 +174,13 @@ class AuthStack(Stack):
             value=domain.base_url(),
         )
 
+        CfnOutput(
+            self,
+            "cognito-domain",
+            export_name=f"{stack_name}-cognito_domain",
+            value=domain.base_url(),
+        )
+
         return domain
 
     def _get_client_secret(

--- a/infra/stack.py
+++ b/infra/stack.py
@@ -177,7 +177,7 @@ class AuthStack(Stack):
         CfnOutput(
             self,
             "cognito-domain",
-            export_name=f"{stack_name}-cognito_domain",
+            export_name=f"{stack_name}-cognito-domain",
             value=domain.base_url(),
         )
 


### PR DESCRIPTION
# What
Export expected cognito-domain variable name for downstream services.