### PR TITLE
fix: export name hyphen

### DIFF
--- a/infra/stack.py
+++ b/infra/stack.py
@@ -177,7 +177,7 @@ class AuthStack(Stack):
         CfnOutput(
             self,
             "cognito-domain",
-            export_name=f"{stack_name}-cognito_domain",
+            export_name=f"{stack_name}-cognito-domain",
             value=domain.base_url(),
         )
 


### PR DESCRIPTION
# what
use hyphen not underscore in cfn export name