### PR TITLE
add veda-ingest-ui similar to programmatic-client

### DIFF
--- a/app.py
+++ b/app.py
@@ -106,6 +106,15 @@ CfnOutput(
     value=client.user_pool_client_id,
 )
 
+# Veda Ingest UI Client
+client = stack.add_programmatic_client("veda-ingest-ui")
+CfnOutput(
+    stack,
+    "client_id",
+    export_name=f"{app_settings.app_name}-{app_settings.stage}-client-id",
+    value=client.user_pool_client_id,
+)
+
 # Frontend Clients
 # stack.add_frontend_client('veda-dashboard')
 


### PR DESCRIPTION
the veda-ingest-ui is using the `veda-ingest-ui` app client with the `veda-auth-stack-staging` Cognito User Pool. There was already an existing `programmatic-client` app client, and this is intended to duplicate that configuration.