### PR TITLE
fix: update workflows to use full commit hash

### DIFF
--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -20,7 +20,7 @@ runs:
       with:
         node-version: 20
 
-    - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3.3.3
+    - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
@@ -55,7 +55,6 @@ runs:
         else
         python ${{ inputs.script_path }} --secret-id ${{ inputs.env_aws_secret_name }}
         fi
-
 
     - name: Deploy
       id: deploy_auth_stack

--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -16,11 +16,11 @@ runs:
   using: "composite"
   steps:
     - name: Install node and related deps
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e4 #v4.3.0
       with:
         node-version: 20
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3.3.3
       with:
         path: ~/.npm
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
@@ -30,7 +30,7 @@ runs:
       run: npm install -g aws-cdk@2
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: "3.10"
         cache: "pip"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -59,7 +59,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
 
-      - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3.3.3
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: ~/.npm
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
@@ -67,10 +67,10 @@ jobs:
       - name: Install CDK
         run: npm install -g aws-cdk@2
 
-      - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3.3.3
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: ${{ env.pythonLocation }}
-          key:  ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -41,45 +41,45 @@ jobs:
     concurrency: ${{ needs.define-environment.outputs.env_name }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa #v4.8.0
         with:
           python-version: '3.9'
-      
+
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 #v3.8.2
         with:
           node-version: 20
 
       - name: Configure awscli
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 #v3.0.2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-      
-      - uses: actions/cache@v3
+
+      - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3.3.3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install CDK
         run: npm install -g aws-cdk@2
-        
-      - uses: actions/cache@v3
+
+      - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3.3.3
         with:
           path: ${{ env.pythonLocation }}
           key:  ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
-          
+
       - name: Install python dependencies
         run: |
           pip install -r requirements.txt
-          
+
       - name: Get environment configuration for target branch
         run: |
           ./scripts/get-env.sh ${{ needs.define-environment.outputs.secret_name }}
-          
+
       - name: Deploy
         run: |
           echo $STAGE

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,6 @@ jobs:
       env_name: ${{ steps.define_environment.outputs.env_name }}
       secret_name: ${{ steps.define_environment.outputs.secret_name }}
 
-
   predeploy:
     name: Pre-deploy cdk diff for ${{ needs.define-environment.outputs.env_name }} 🚀
     needs: [define-environment]
@@ -52,7 +51,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
 
-      - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3.3.3
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: ~/.npm
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
@@ -60,14 +59,14 @@ jobs:
       - name: Install CDK
         run: npm install -g aws-cdk@2
 
-      - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3.3.3
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: ${{ env.pythonLocation }}
-          key:  ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
 
       - name: Install python dependencies
         run: |
-            pip install -r requirements.txt
+          pip install -r requirements.txt
 
       - name: Get environment configuration for target branch
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,32 +27,32 @@ jobs:
     outputs:
       env_name: ${{ steps.define_environment.outputs.env_name }}
       secret_name: ${{ steps.define_environment.outputs.secret_name }}
-    
+
 
   predeploy:
     name: Pre-deploy cdk diff for ${{ needs.define-environment.outputs.env_name }} 🚀
     needs: [define-environment]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa #v4.8.0
         with:
           python-version: '3.9'
-      
+
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 #v3.8.2
         with:
           node-version: 20
 
       - name: Configure awscli
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 #v3.0.2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3.3.3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
@@ -60,7 +60,7 @@ jobs:
       - name: Install CDK
         run: npm install -g aws-cdk@2
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3.3.3
         with:
           path: ${{ env.pythonLocation }}
           key:  ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,6 +32,7 @@ jobs:
     name: Pre-deploy cdk diff for ${{ needs.define-environment.outputs.env_name }} 🚀
     needs: [define-environment]
     runs-on: ubuntu-latest
+    environment: ${{ needs.define-environment.outputs.env_name }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
       - name: Set up Python
@@ -47,8 +48,7 @@ jobs:
       - name: Configure awscli
         uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 #v3.0.2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE }}
           aws-region: us-west-2
 
       - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2


### PR DESCRIPTION
Relevant issue: https://github.com/NASA-IMPACT/veda-architecture/issues/569

- actions/checkout@v4 pinned to [v4.2.2](https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683)
- actions/setup-python@v5 pinned to [v.5.4.0](https://github.com/actions/setup-python/releases/tag/v5.4.0)
- actions/checkout@v3 pinned to [v3.6.0](https://github.com/actions/checkout/commit/f43a0e5ff2bd294095638e18286ca9a3d1956744)
- actions/cache@v3 pinned to [v3.3.3](https://github.com/actions/cache/commit/e12d46a63a90f2fae62d114769bbf2a179198b5c)
- actions/setup-node@v4 pinned to [v3.8.2](https://github.com/actions/setup-node/commit/1a4442cacd436585916779262731d5b162bc6ec7)
- Also updated to use OIDC. 